### PR TITLE
🔧 Hotfix: Remove non-existent labels from workflow

### DIFF
--- a/.github/workflows/manual-sync-docs.yml
+++ b/.github/workflows/manual-sync-docs.yml
@@ -596,7 +596,6 @@ jobs:
         gh pr create \
           --title "🤖 AI-Powered Documentation Sync - ${{ github.run_id }}" \
           --body-file claude_pr_body.md \
-          --label "documentation,sync,ai-powered,claude" \
           --base main \
           --head "$PR_BRANCH"
         


### PR DESCRIPTION
## 🐛 Problem

The AI-powered documentation sync workflow is still failing after PR #5 was merged because of this error:
```
could not add label: 'sync' not found
```

## 🔧 Solution

Remove the `--label` parameter from the `gh pr create` command since the labels don't exist in the repository.

## ✅ Test Results

This addresses the failure in run [16226437564](https://github.com/toplocs/toplocs-workspace/actions/runs/16226437564) where the workflow successfully:
- ✅ Created the branch
- ✅ Committed changes  
- ✅ Pushed to origin
- ❌ Failed only on the label assignment

After this fix, the workflow should complete successfully.